### PR TITLE
fix: mask样式问题

### DIFF
--- a/src/Mask.tsx
+++ b/src/Mask.tsx
@@ -62,7 +62,7 @@ const Mask = (props: MaskProps) => {
           >
             <defs>
               <mask id={maskId}>
-                <rect x="0" y="0" width="100%" height="100%" fill="white" />
+                <rect x="0" y="0" width="100vw" height="100vh" fill="white" />
                 {pos && (
                   <rect
                     x={pos.left}

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -91,8 +91,8 @@ exports[`Tour animated placeholder true 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -244,8 +244,8 @@ exports[`Tour animated true 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -383,8 +383,8 @@ exports[`Tour renderPanel 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -536,8 +536,8 @@ exports[`Tour rootClassName 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -700,8 +700,8 @@ exports[`Tour run in strict mode 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -832,8 +832,8 @@ exports[`Tour run in strict mode 2`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -991,8 +991,8 @@ exports[`Tour should keep current when controlled 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -1104,8 +1104,8 @@ exports[`Tour should return step 1 when reopen 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -1218,8 +1218,8 @@ exports[`Tour should update position when window resize 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -1367,8 +1367,8 @@ exports[`Tour showArrow should show tooltip arrow default 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -1520,8 +1520,8 @@ exports[`Tour single 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -1675,8 +1675,8 @@ exports[`Tour use custom builtinPlacements 1`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />
@@ -1830,8 +1830,8 @@ exports[`Tour use custom builtinPlacements 2`] = `
           >
             <rect
               fill="white"
-              height="100%"
-              width="100%"
+              height="100vh"
+              width="100vw"
               x="0"
               y="0"
             />


### PR DESCRIPTION
线上文档 mask 遮罩 从小屏换到大屏的时候会留有空白

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/13554001/216913574-53c535de-926c-4ae1-977a-1d266c4c7760.png">
