### PR TITLE
fix: scroll into view default options unreasonable sometime

### DIFF
--- a/src/Tour.tsx
+++ b/src/Tour.tsx
@@ -23,6 +23,10 @@ const CENTER_PLACEHOLDER: React.CSSProperties = {
   width: 1,
   height: 1,
 };
+const defaultScrollIntoViewOptions: ScrollIntoViewOptions = {
+  block: "center",
+  inline: "center"
+}
 
 export interface TourProps
   extends Pick<TriggerProps, 'onPopupAlign'> {
@@ -72,7 +76,7 @@ const Tour: React.FC<TourProps> = props => {
     renderPanel,
     gap,
     animated,
-    scrollIntoViewOptions = { block: "center", inline: "center" },
+    scrollIntoViewOptions = defaultScrollIntoViewOptions,
     zIndex = 1001,
     closeIcon,
     builtinPlacements,
@@ -111,7 +115,7 @@ const Tour: React.FC<TourProps> = props => {
     arrow: stepArrow,
     className: stepClassName,
     mask: stepMask,
-    scrollIntoViewOptions: stepScrollIntoViewOptions,
+    scrollIntoViewOptions: stepScrollIntoViewOptions = defaultScrollIntoViewOptions,
     closeIcon: stepCloseIcon,
   } = steps[mergedCurrent] || {};
 

--- a/src/Tour.tsx
+++ b/src/Tour.tsx
@@ -72,7 +72,7 @@ const Tour: React.FC<TourProps> = props => {
     renderPanel,
     gap,
     animated,
-    scrollIntoViewOptions = true,
+    scrollIntoViewOptions = { block: "center", inline: "center" },
     zIndex = 1001,
     closeIcon,
     builtinPlacements,


### PR DESCRIPTION
# Description
Before
![image](https://github.com/react-component/tour/assets/97073795/f44411f2-4f04-4c58-a0b8-81e2bc7db502)
After
![image](https://github.com/react-component/tour/assets/97073795/33b6910c-869e-47ff-81d8-dd63527377b7)
