### PR TITLE
fix: closeIcon should be `undefined` for customize panel render

### DIFF
--- a/src/Tour.tsx
+++ b/src/Tour.tsx
@@ -92,7 +92,6 @@ const Tour: React.FC<TourProps> = props => {
   } = steps[mergedCurrent] || {};
 
   const mergedClosable = useClosable(
-    prefixCls,
     stepClosable,
     stepCloseIcon,
     closable,

--- a/src/TourStep/DefaultPanel.tsx
+++ b/src/TourStep/DefaultPanel.tsx
@@ -22,7 +22,7 @@ export default function DefaultPanel(props: DefaultPanelProps) {
     closable,
   } = props;
   const ariaProps = pickAttrs(closable || {}, true);
-  const closeIcon = closable?.closeIcon;
+  const closeIcon = closable?.closeIcon ?? <span className={`${prefixCls}-close-x`}>&times;</span>;
   const mergedClosable = !!closable;
 
   return (

--- a/src/hooks/useClosable.tsx
+++ b/src/hooks/useClosable.tsx
@@ -2,16 +2,7 @@ import * as React from 'react';
 import type { TourProps } from '../interface';
 import type { TourStepInfo } from '../TourStep';
 
-type ClosableConfig =
-  | (Exclude<TourStepInfo['closable'], boolean> & {
-      /**
-       * @private Tell if current closeIcon is provided by `rc-tour`.
-       * It's useful to let custom panel to know if need to render default closeIcon.
-       * And this is safe to remove if next major version.
-       */
-      defaultIcon: boolean;
-    })
-  | null;
+type ClosableConfig = Exclude<TourStepInfo['closable'], boolean> | null;
 
 function isConfigObj(
   closable: TourStepInfo['closable'],
@@ -48,17 +39,13 @@ function getClosableConfig(
     return null;
   }
 
-  const defaultIcon = <span className={`${prefixCls}-close-x`}>&times;</span>;
   const mergedCloseIcon =
-    (typeof closeIcon !== 'boolean' && closeIcon) || defaultIcon;
+    typeof closeIcon !== 'boolean' ? closeIcon : undefined;
 
   if (isConfigObj(closable)) {
-    const mergedConfigCloseIcon = closable.closeIcon || defaultIcon;
-
     return {
       ...closable,
-      closeIcon: mergedConfigCloseIcon,
-      defaultIcon: mergedConfigCloseIcon === defaultIcon,
+      closeIcon: closable.closeIcon ?? mergedCloseIcon,
     };
   }
 
@@ -66,7 +53,6 @@ function getClosableConfig(
   return preset || closable || closeIcon
     ? {
         closeIcon: mergedCloseIcon,
-        defaultIcon: mergedCloseIcon === defaultIcon,
       }
     : 'empty';
 }

--- a/src/hooks/useClosable.tsx
+++ b/src/hooks/useClosable.tsx
@@ -11,13 +11,11 @@ function isConfigObj(
 }
 
 function getClosableConfig(
-  prefixCls: string,
   closable: TourStepInfo['closable'],
   closeIcon: TourStepInfo['closeIcon'],
   preset: true,
 ): ClosableConfig;
 function getClosableConfig(
-  prefixCls: string,
   closable: TourStepInfo['closable'],
   closeIcon: TourStepInfo['closeIcon'],
   preset: false,
@@ -27,7 +25,6 @@ function getClosableConfig(
  * When `preset` is true, will auto fill ClosableConfig with default value.
  */
 function getClosableConfig(
-  prefixCls: string,
   closable: TourStepInfo['closable'],
   closeIcon: TourStepInfo['closeIcon'],
   preset: boolean,
@@ -58,7 +55,6 @@ function getClosableConfig(
 }
 
 export function useClosable(
-  prefixCls: string,
   stepClosable: TourStepInfo['closable'],
   stepCloseIcon: TourStepInfo['closeIcon'],
   closable: TourProps['closable'],
@@ -66,23 +62,17 @@ export function useClosable(
 ) {
   return React.useMemo(() => {
     const stepClosableConfig = getClosableConfig(
-      prefixCls,
       stepClosable,
       stepCloseIcon,
       false,
     );
 
-    const rootClosableConfig = getClosableConfig(
-      prefixCls,
-      closable,
-      closeIcon,
-      true,
-    );
+    const rootClosableConfig = getClosableConfig(closable, closeIcon, true);
 
     if (stepClosableConfig !== 'empty') {
       return stepClosableConfig;
     }
 
     return rootClosableConfig;
-  }, [closable, closeIcon, prefixCls, stepClosable, stepCloseIcon]);
+  }, [closable, closeIcon, stepClosable, stepCloseIcon]);
 }

--- a/src/hooks/useClosable.tsx
+++ b/src/hooks/useClosable.tsx
@@ -2,7 +2,16 @@ import * as React from 'react';
 import type { TourProps } from '../interface';
 import type { TourStepInfo } from '../TourStep';
 
-type ClosableConfig = Exclude<TourStepInfo['closable'], boolean> | null;
+type ClosableConfig =
+  | (Exclude<TourStepInfo['closable'], boolean> & {
+      /**
+       * @private Tell if current closeIcon is provided by `rc-tour`.
+       * It's useful to let custom panel to know if need to render default closeIcon.
+       * And this is safe to remove if next major version.
+       */
+      defaultIcon: boolean;
+    })
+  | null;
 
 function isConfigObj(
   closable: TourStepInfo['closable'],
@@ -44,9 +53,12 @@ function getClosableConfig(
     (typeof closeIcon !== 'boolean' && closeIcon) || defaultIcon;
 
   if (isConfigObj(closable)) {
+    const mergedConfigCloseIcon = closable.closeIcon || defaultIcon;
+
     return {
       ...closable,
-      closeIcon: closable.closeIcon || mergedCloseIcon,
+      closeIcon: mergedConfigCloseIcon,
+      defaultIcon: mergedConfigCloseIcon === defaultIcon,
     };
   }
 
@@ -54,6 +66,7 @@ function getClosableConfig(
   return preset || closable || closeIcon
     ? {
         closeIcon: mergedCloseIcon,
+        defaultIcon: mergedCloseIcon === defaultIcon,
       }
     : 'empty';
 }

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -334,7 +334,7 @@ exports[`Tour basic 1`] = `
 </body>
 `;
 
-exports[`Tour renderPanel 1`] = `
+exports[`Tour renderPanel basic 1`] = `
 <body>
   <div>
     <div

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -90,33 +90,86 @@ describe('Tour', () => {
     expect(baseElement).toMatchSnapshot();
   });
 
-  it('renderPanel', async () => {
-    const Demo = () => {
-      const btnRef = useRef<HTMLButtonElement>(null);
-      return (
-        <div style={{ margin: 20 }}>
-          <button ref={btnRef}>按钮</button>
-          <Tour
-            placement={'bottom'}
-            steps={[
-              {
-                title: '创建',
-                description: '创建一条数据',
-                target: () => btnRef.current,
-              },
-            ]}
-            renderPanel={(props, current) => (
-              <div>
-                {props.title},当前在第{current}步,描述为{props.description}
-              </div>
-            )}
-          />
-        </div>
+  describe('renderPanel', () => {
+    it('basic', async () => {
+      const Demo = () => {
+        const btnRef = useRef<HTMLButtonElement>(null);
+        return (
+          <div style={{ margin: 20 }}>
+            <button ref={btnRef}>按钮</button>
+            <Tour
+              placement={'bottom'}
+              steps={[
+                {
+                  title: '创建',
+                  description: '创建一条数据',
+                  target: () => btnRef.current,
+                },
+              ]}
+              renderPanel={(props, current) => (
+                <div>
+                  {props.title},当前在第{current}步,描述为{props.description}
+                </div>
+              )}
+            />
+          </div>
+        );
+      };
+      const { getByText, baseElement } = render(<Demo />);
+      expect(getByText('创建,当前在第0步,描述为创建一条数据')).toBeTruthy();
+      expect(baseElement).toMatchSnapshot();
+    });
+
+    it('closable.defaultIcon', () => {
+      const renderPanel = jest.fn(() => null);
+
+      const { rerender } = render(
+        <Tour
+          open
+          steps={[
+            {
+              title: 'bamboo',
+              description: 'little',
+            },
+          ]}
+          renderPanel={renderPanel}
+        />,
       );
-    };
-    const { getByText, baseElement } = render(<Demo />);
-    expect(getByText('创建,当前在第0步,描述为创建一条数据')).toBeTruthy();
-    expect(baseElement).toMatchSnapshot();
+
+      expect(renderPanel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          closable: expect.objectContaining({
+            defaultIcon: true,
+          }),
+        }),
+        0,
+      );
+
+      // Customize
+      renderPanel.mockReset();
+      rerender(
+        <Tour
+          open
+          steps={[
+            {
+              title: 'bamboo',
+              description: 'little',
+            },
+          ]}
+          renderPanel={renderPanel}
+          closeIcon={<span />}
+        />,
+      );
+
+      expect(renderPanel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          closable: expect.objectContaining({
+            defaultIcon: false,
+          }),
+        }),
+        0,
+      );
+    });
   });
 
   it('basic', () => {
@@ -680,7 +733,9 @@ describe('Tour', () => {
             animated={false}
             open={open}
             placement={'bottom'}
-            builtinPlacements={config => getPlacements(config.arrowPointAtCenter)}
+            builtinPlacements={config =>
+              getPlacements(config.arrowPointAtCenter)
+            }
             steps={[
               {
                 title: '创建',
@@ -890,7 +945,11 @@ describe('Tour', () => {
   });
 
   it('support closable', () => {
-    const Demo = ({ closable = false }: { closable?: TourProps["closable"] }) => {
+    const Demo = ({
+      closable = false,
+    }: {
+      closable?: TourProps['closable'];
+    }) => {
       const createBtnRef = useRef<HTMLButtonElement>(null);
       const updateBtnRef = useRef<HTMLButtonElement>(null);
       const deleteBtnRef = useRef<HTMLButtonElement>(null);
@@ -927,8 +986,10 @@ describe('Tour', () => {
               {
                 title: '删除',
                 closable: {
-                  closeIcon: <span className="custom-del-close-icon">Close</span>,
-                  "aria-label": "关闭",
+                  closeIcon: (
+                    <span className="custom-del-close-icon">Close</span>
+                  ),
+                  'aria-label': '关闭',
                 },
                 description: (
                   <div>
@@ -959,7 +1020,9 @@ describe('Tour', () => {
     expect(baseElement.querySelector('.rc-tour-close')).toBeTruthy();
     expect(baseElement.querySelector('.rc-tour-close-x')).toBeFalsy();
     expect(baseElement.querySelector('.custom-del-close-icon')).toBeTruthy();
-    expect(baseElement.querySelector('.rc-tour-close').getAttribute("aria-label")).toBe("关闭");
+    expect(
+      baseElement.querySelector('.rc-tour-close').getAttribute('aria-label'),
+    ).toBe('关闭');
 
     resetIndex();
 
@@ -973,19 +1036,25 @@ describe('Tour', () => {
     expect(baseElement.querySelector('.rc-tour-close')).toBeTruthy();
     expect(baseElement.querySelector('.rc-tour-close-x')).toBeFalsy();
     expect(baseElement.querySelector('.custom-del-close-icon')).toBeTruthy();
-    expect(baseElement.querySelector('.rc-tour-close').getAttribute("aria-label")).toBe("关闭");
+    expect(
+      baseElement.querySelector('.rc-tour-close').getAttribute('aria-label'),
+    ).toBe('关闭');
 
     resetIndex();
 
     rerender(
-      <Demo closable={{
-        closeIcon: <span className="custom-global-close-icon">X</span>,
-        "aria-label": "关闭",
-      }} />,
+      <Demo
+        closable={{
+          closeIcon: <span className="custom-global-close-icon">X</span>,
+          'aria-label': '关闭',
+        }}
+      />,
     );
     expect(baseElement.querySelector('.rc-tour-close')).toBeTruthy();
     expect(baseElement.querySelector('.custom-global-close-icon')).toBeTruthy();
-    expect(baseElement.querySelector('.rc-tour-close').getAttribute("aria-label")).toBe("关闭");
+    expect(
+      baseElement.querySelector('.rc-tour-close').getAttribute('aria-label'),
+    ).toBe('关闭');
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
     expect(baseElement.querySelector('.rc-tour-close')).toBeFalsy();
     expect(baseElement.querySelector('.rc-tour-close-x')).toBeFalsy();
@@ -1070,6 +1139,8 @@ describe('Tour', () => {
 
     render(<Demo />);
 
-    expect(document.querySelector('.rc-tour-mask')).toHaveStyle('pointer-events: auto')
-  })
+    expect(document.querySelector('.rc-tour-mask')).toHaveStyle(
+      'pointer-events: auto',
+    );
+  });
 });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -120,10 +120,10 @@ describe('Tour', () => {
       expect(baseElement).toMatchSnapshot();
     });
 
-    it('closable.defaultIcon', () => {
+    it('closable.closeIcon should be empty', () => {
       const renderPanel = jest.fn(() => null);
 
-      const { rerender } = render(
+      render(
         <Tour
           open
           steps={[
@@ -139,32 +139,7 @@ describe('Tour', () => {
       expect(renderPanel).toHaveBeenCalledWith(
         expect.objectContaining({
           closable: expect.objectContaining({
-            defaultIcon: true,
-          }),
-        }),
-        0,
-      );
-
-      // Customize
-      renderPanel.mockReset();
-      rerender(
-        <Tour
-          open
-          steps={[
-            {
-              title: 'bamboo',
-              description: 'little',
-            },
-          ]}
-          renderPanel={renderPanel}
-          closeIcon={<span />}
-        />,
-      );
-
-      expect(renderPanel).toHaveBeenCalledWith(
-        expect.objectContaining({
-          closable: expect.objectContaining({
-            defaultIcon: false,
+            closeIcon: undefined,
           }),
         }),
         0,


### PR DESCRIPTION
`closeIcon` 在原本逻辑中，只有 DefaultPanel 下才会使用，自定时不会填充。复原该逻辑。