### PR TITLE
fix: findDOMNode warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^13.0.0",
+    "@testing-library/react": "^15.0.0",
     "@types/jest": "^29.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
@@ -59,8 +59,8 @@
     "gh-pages": "^3.1.0",
     "np": "^5.0.3",
     "prettier": "^3.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "typescript": "^5.0.0",
     "umi-test": "^1.9.7"
   },

--- a/src/Tour.tsx
+++ b/src/Tour.tsx
@@ -69,11 +69,18 @@ const Tour: React.FC<TourProps> = props => {
         : origin ?? true,
   });
 
+  // Record if already rended in the DOM to avoid `findDOMNode` issue
+  const [hasOpened, setHasOpened] = React.useState(mergedOpen);
+
   const openRef = React.useRef(mergedOpen);
 
   useLayoutEffect(() => {
-    if (mergedOpen && !openRef.current) {
-      setMergedCurrent(0);
+    if (mergedOpen) {
+      if (!openRef.current) {
+        setMergedCurrent(0);
+      }
+
+      setHasOpened(true);
     }
     openRef.current = mergedOpen;
   }, [mergedOpen]);
@@ -139,7 +146,7 @@ const Tour: React.FC<TourProps> = props => {
 
   // ========================= Render =========================
   // Skip if not init yet
-  if (targetElement === undefined) {
+  if (targetElement === undefined || !hasOpened) {
     return null;
   }
 

--- a/tests/React.test.tsx
+++ b/tests/React.test.tsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import Tour from '../src/index';
+
+describe('Tour.React', () => {
+  let spy: jest.SpyInstance;
+
+  beforeAll(() => {
+    spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    spy.mockRestore();
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    spy.mockReset();
+  });
+
+  it('not warning', () => {
+    const renderDemo = (open: boolean) => (
+      <React.StrictMode>
+        <Tour
+          open={open}
+          steps={[
+            {
+              title: 'Center',
+              description: 'Displayed in the center of screen.',
+              target: null,
+            },
+          ]}
+        />
+      </React.StrictMode>
+    );
+
+    const {} = render(renderDemo(false));
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
在 Tour 没有展示之前，不存在 DOM 节点。因而会被降级为 `findDOMNode` 再次尝试查找。调整逻辑，让其在未渲染阶段跳过整个 Trigger。