### PR TITLE
fix: 修复scrollIntoView的参数behavior设置为smooth时引导面板定位异常的问题 #50509

### DIFF
--- a/docs/examples/scrollIntoView.tsx
+++ b/docs/examples/scrollIntoView.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, {useRef, useState} from 'react';
 import Tour from '../../src/index';
 import './basic.less';
 
@@ -65,7 +65,7 @@ const App = () => {
             ),
             target: () => updateBtnRef.current,
             scrollIntoViewOptions: {
-              block: 'start'
+              block: 'start', behavior:'smooth'
             }
           },
           {

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,3 +18,16 @@ export function getPlacement(
     stepPlacement ?? placement ?? (targetElement === null ? 'center' : 'bottom')
   );
 }
+
+export function debounce<T extends (...args: any[]) => any>(func: T, wait: number): T {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const debouncedFunc = (...args: Parameters<T>): void => {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => {
+            func(...args);
+        }, wait);
+    };
+
+    return debouncedFunc as T;
+}


### PR DESCRIPTION
修复ant-design tour引导组件设置滚动参数behavior:smooth时定位异常的问题 [#50509](https://github.com/ant-design/ant-design/issues/50509)

https://github.com/user-attachments/assets/051edc28-bf97-4a2c-b516-4df4c20ff246

