### PR TITLE
fix:render rx with 2 when gap.radius is 0

### DIFF
--- a/src/hooks/useTarget.ts
+++ b/src/hooks/useTarget.ts
@@ -16,7 +16,9 @@ export interface PosInfo {
   width: number;
   radius: number;
 }
-
+function isValidNumber(val) {
+  return typeof val === 'number' && !Number.isNaN(val);
+}
 export default function useTarget(
   target: TourStepInfo['target'],
   open: boolean,
@@ -82,7 +84,7 @@ export default function useTarget(
 
     const gapOffsetX = getGapOffset(0);
     const gapOffsetY = getGapOffset(1);
-    const gapRadius = gap?.radius || 2;
+    const gapRadius = isValidNumber(gap?.radius) ? gap?.radius : 2;
 
     return {
       left: posInfo.left - gapOffsetX,

--- a/src/hooks/useTarget.ts
+++ b/src/hooks/useTarget.ts
@@ -19,6 +19,7 @@ export interface PosInfo {
 function isValidNumber(val) {
   return typeof val === 'number' && !Number.isNaN(val);
 }
+
 export default function useTarget(
   target: TourStepInfo['target'],
   open: boolean,

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1086,7 +1086,36 @@ describe('Tour', () => {
     expect(targetRect).toHaveAttribute('width', '270');
     expect(targetRect).toHaveAttribute('height', '340');
   });
-
+  it("render rx with 0 instead of 2 when gap.radius is 0", () => {
+    const Demo = ({radius}) => {
+      const btnRef = useRef<HTMLButtonElement>(null);
+      return (
+        <div style={{ margin: 20 }}>
+          <button ref={btnRef}>按钮</button>
+          <Tour
+            placement={'bottom'}
+            gap={{
+              radius,
+            }}
+            open={true}
+            steps={[
+              {
+                title: '创建',
+                description: '创建一条数据',
+                target: () => btnRef.current,
+              },
+            ]}
+          />
+        </div>
+      );
+    };
+    render(<Demo radius={0} />);
+    const targetRect = document
+      .getElementById('rc-tour-mask-test-id')
+      .querySelectorAll('rect')[1];
+    expect(targetRect).toBeTruthy();
+    expect(targetRect).toHaveAttribute('rx', '0');
+  }) 
   it('disabledInteraction should work', () => {
     const Demo = () => {
       const btnRef = useRef<HTMLButtonElement>(null);

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1086,7 +1086,8 @@ describe('Tour', () => {
     expect(targetRect).toHaveAttribute('width', '270');
     expect(targetRect).toHaveAttribute('height', '340');
   });
-  it("render rx with 0 instead of 2 when gap.radius is 0", () => {
+
+  it('render rx with 0 instead of 2 when gap.radius is 0', () => {
     const Demo = ({radius}) => {
       const btnRef = useRef<HTMLButtonElement>(null);
       return (

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1115,7 +1115,8 @@ describe('Tour', () => {
       .querySelectorAll('rect')[1];
     expect(targetRect).toBeTruthy();
     expect(targetRect).toHaveAttribute('rx', '0');
-  }) 
+  });
+
   it('disabledInteraction should work', () => {
     const Demo = () => {
       const btnRef = useRef<HTMLButtonElement>(null);


### PR DESCRIPTION
https://github.com/ant-design/ant-design/pull/50574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了一个新的实用函数 `isValidNumber`，用于验证 `gap?.radius` 的有效性，以增强代码的健壮性。
  
- **测试**
	- 在 `Tour` 组件的测试套件中新增了测试用例，确保当 `gap.radius` 为 0 时，SVG 矩形的 `rx` 属性正确渲染为 '0'，提高了测试覆盖率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->