### PR TITLE
feat: Tour support classnames and styles

### DIFF
--- a/docs/examples/basic.less
+++ b/docs/examples/basic.less
@@ -29,7 +29,7 @@
 }
 
 // Wrapper for the tour content
-.@{tour-prefix-cls}-inner {
+.@{tour-prefix-cls}-body {
   text-align: left;
   text-decoration: none;
   border-radius: 6px;;

--- a/docs/examples/basic.less
+++ b/docs/examples/basic.less
@@ -29,7 +29,7 @@
 }
 
 // Wrapper for the tour content
-.@{tour-prefix-cls}-body {
+.@{tour-prefix-cls}-section {
   text-align: left;
   text-decoration: none;
   border-radius: 6px;;

--- a/src/Mask.tsx
+++ b/src/Mask.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import Portal from '@rc-component/portal';
 import type { PosInfo } from './hooks/useTarget';
 import useId from 'rc-util/lib/hooks/useId';
+import { SemanticName } from './interface';
 
 const COVER_PROPS = {
   fill: 'transparent',
@@ -21,6 +22,8 @@ export interface MaskProps {
   animated?: boolean | { placeholder: boolean };
   zIndex?: number;
   disabledInteraction?: boolean;
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 }
 
 const Mask = (props: MaskProps) => {
@@ -34,7 +37,9 @@ const Mask = (props: MaskProps) => {
     open,
     animated,
     zIndex,
-    disabledInteraction
+    disabledInteraction,
+    styles,
+    classNames: tourClassNames,
   } = props;
 
   const id = useId();
@@ -48,7 +53,7 @@ const Mask = (props: MaskProps) => {
   return (
     <Portal open={open} autoLock>
       <div
-        className={classNames(`${prefixCls}-mask`, rootClassName)}
+        className={classNames(`${prefixCls}-mask`, rootClassName, tourClassNames?.mask)}
         style={{
           position: 'fixed',
           left: 0,
@@ -57,7 +62,8 @@ const Mask = (props: MaskProps) => {
           bottom: 0,
           zIndex,
           pointerEvents: pos && !disabledInteraction ? 'none' : 'auto',
-          ...style
+          ...style,
+          ...styles?.mask,
         }}
       >
         {showMask ? (

--- a/src/Tour.tsx
+++ b/src/Tour.tsx
@@ -51,6 +51,8 @@ const Tour: React.FC<TourProps> = props => {
     closable,
     builtinPlacements,
     disabledInteraction,
+    styles,
+    classNames: tourClassNames,
     ...restProps
   } = props;
 
@@ -66,7 +68,7 @@ const Tour: React.FC<TourProps> = props => {
     postState: origin =>
       mergedCurrent < 0 || mergedCurrent >= steps.length
         ? false
-        : origin ?? true,
+        : (origin ?? true),
   });
 
   // Record if already rended in the DOM to avoid `findDOMNode` issue
@@ -157,6 +159,8 @@ const Tour: React.FC<TourProps> = props => {
 
   const getPopupElement = () => (
     <TourStep
+      styles={styles}
+      classNames={tourClassNames}
       arrow={mergedArrow}
       key="content"
       prefixCls={prefixCls}
@@ -192,6 +196,8 @@ const Tour: React.FC<TourProps> = props => {
   return (
     <>
       <Mask
+        styles={styles}
+        classNames={tourClassNames}
         zIndex={zIndex}
         prefixCls={prefixCls}
         pos={posInfo}

--- a/src/Tour.tsx
+++ b/src/Tour.tsx
@@ -53,6 +53,8 @@ const Tour: React.FC<TourProps> = props => {
     disabledInteraction,
     styles,
     classNames: tourClassNames,
+    className,
+    style,
     ...restProps
   } = props;
 
@@ -228,6 +230,7 @@ const Tour: React.FC<TourProps> = props => {
         <Portal open={mergedOpen} autoLock>
           <div
             className={classNames(
+              className,
               rootClassName,
               `${prefixCls}-target-placeholder`,
             )}
@@ -235,6 +238,7 @@ const Tour: React.FC<TourProps> = props => {
               ...(posInfo || CENTER_PLACEHOLDER),
               position: 'fixed',
               pointerEvents: 'none',
+              ...style,
             }}
           />
         </Portal>

--- a/src/TourStep/DefaultPanel.tsx
+++ b/src/TourStep/DefaultPanel.tsx
@@ -30,17 +30,10 @@ export default function DefaultPanel(props: DefaultPanelProps) {
   const mergedClosable = !!closable;
 
   return (
-    <div
-      className={classNames(
-        `${prefixCls}-section`,
-        tourClassNames?.section,
-        className,
-      )}
-      style={styles?.section}
-    >
+    <div className={classNames(`${prefixCls}-pannel`, className)}>
       <div
-        className={classNames(`${prefixCls}-body`, tourClassNames?.body)}
-        style={styles?.body}
+        className={classNames(`${prefixCls}-section`, tourClassNames?.section)}
+        style={styles?.section}
       >
         {mergedClosable && (
           <button

--- a/src/TourStep/DefaultPanel.tsx
+++ b/src/TourStep/DefaultPanel.tsx
@@ -32,11 +32,11 @@ export default function DefaultPanel(props: DefaultPanelProps) {
   return (
     <div
       className={classNames(
-        `${prefixCls}-content`,
-        tourClassNames?.content,
+        `${prefixCls}-section`,
+        tourClassNames?.section,
         className,
       )}
-      style={styles?.content}
+      style={styles?.section}
     >
       <div
         className={classNames(`${prefixCls}-body`, tourClassNames?.body)}

--- a/src/TourStep/DefaultPanel.tsx
+++ b/src/TourStep/DefaultPanel.tsx
@@ -3,8 +3,8 @@ import type { TourStepProps } from '../interface';
 import classNames from 'classnames';
 import pickAttrs from 'rc-util/lib/pickAttrs';
 
-export type DefaultPanelProps = Exclude<TourStepProps, "closable"> & {
-  closable: Exclude<TourStepProps["closable"], boolean>;
+export type DefaultPanelProps = Exclude<TourStepProps, 'closable'> & {
+  closable: Exclude<TourStepProps['closable'], boolean>;
 };
 
 export default function DefaultPanel(props: DefaultPanelProps) {
@@ -20,14 +20,28 @@ export default function DefaultPanel(props: DefaultPanelProps) {
     onFinish,
     className,
     closable,
+    classNames: tourClassNames,
+    styles,
   } = props;
   const ariaProps = pickAttrs(closable || {}, true);
-  const closeIcon = closable?.closeIcon ?? <span className={`${prefixCls}-close-x`}>&times;</span>;
+  const closeIcon = closable?.closeIcon ?? (
+    <span className={`${prefixCls}-close-x`}>&times;</span>
+  );
   const mergedClosable = !!closable;
 
   return (
-    <div className={classNames(`${prefixCls}-content`, className)}>
-      <div className={`${prefixCls}-inner`}>
+    <div
+      className={classNames(
+        `${prefixCls}-content`,
+        tourClassNames?.content,
+        className,
+      )}
+      style={styles?.content}
+    >
+      <div
+        className={classNames(`${prefixCls}-body`, tourClassNames?.body)}
+        style={styles?.body}
+      >
         {mergedClosable && (
           <button
             type="button"
@@ -39,24 +53,49 @@ export default function DefaultPanel(props: DefaultPanelProps) {
             {closeIcon}
           </button>
         )}
-        <div className={`${prefixCls}-header`}>
-          <div className={`${prefixCls}-title`}>{title}</div>
+        <div
+          className={classNames(`${prefixCls}-header`, tourClassNames?.header)}
+          style={styles?.header}
+        >
+          <div
+            className={classNames(`${prefixCls}-title`, tourClassNames?.title)}
+            style={styles?.title}
+          >
+            {title}
+          </div>
         </div>
-        <div className={`${prefixCls}-description`}>{description}</div>
-        <div className={`${prefixCls}-footer`}>
+        <div
+          className={classNames(
+            `${prefixCls}-description`,
+            tourClassNames?.description,
+          )}
+          style={styles?.description}
+        >
+          {description}
+        </div>
+        <div
+          className={classNames(`${prefixCls}-footer`, tourClassNames?.footer)}
+          style={styles?.footer}
+        >
           <div className={`${prefixCls}-sliders`}>
             {total > 1
               ? [...Array.from({ length: total }).keys()].map((item, index) => {
-                return (
-                  <span
-                    key={item}
-                    className={index === current ? 'active' : ''}
-                  />
-                );
-              })
+                  return (
+                    <span
+                      key={item}
+                      className={index === current ? 'active' : ''}
+                    />
+                  );
+                })
               : null}
           </div>
-          <div className={`${prefixCls}-buttons`}>
+          <div
+            className={classNames(
+              `${prefixCls}-actions`,
+              tourClassNames?.actions,
+            )}
+            style={styles?.actions}
+          >
             {current !== 0 ? (
               <button className={`${prefixCls}-prev-btn`} onClick={onPrev}>
                 Prev

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -5,7 +5,6 @@ import type { Gap } from './hooks/useTarget';
 import { type DefaultPanelProps } from './TourStep/DefaultPanel';
 
 export type SemanticName =
-  | 'body'
   | 'section'
   | 'footer'
   | 'actions'

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -6,7 +6,7 @@ import { type DefaultPanelProps } from './TourStep/DefaultPanel';
 
 export type SemanticName =
   | 'body'
-  | 'content'
+  | 'section'
   | 'footer'
   | 'actions'
   | 'header'

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -4,6 +4,16 @@ import type { CSSProperties, ReactNode } from 'react';
 import type { Gap } from './hooks/useTarget';
 import { type DefaultPanelProps } from './TourStep/DefaultPanel';
 
+export type SemanticName =
+  | 'body'
+  | 'content'
+  | 'footer'
+  | 'actions'
+  | 'header'
+  | 'title'
+  | 'description'
+  | 'mask';
+
 export interface TourStepInfo {
   arrow?: boolean | { pointAtCenter: boolean };
   target?: HTMLElement | (() => HTMLElement) | null | (() => null);
@@ -33,9 +43,13 @@ export interface TourStepProps extends TourStepInfo {
   renderPanel?: (step: TourStepProps, current: number) => ReactNode;
   onPrev?: () => void;
   onNext?: () => void;
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 }
 
 export interface TourProps extends Pick<TriggerProps, 'onPopupAlign'> {
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
   steps?: TourStepInfo[];
   open?: boolean;
   defaultCurrent?: number;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -50,6 +50,8 @@ export interface TourStepProps extends TourStepInfo {
 export interface TourProps extends Pick<TriggerProps, 'onPopupAlign'> {
   classNames?: Partial<Record<SemanticName, string>>;
   styles?: Partial<Record<SemanticName, React.CSSProperties>>;
+  className?: string;
+  style?: React.CSSProperties;
   steps?: TourStepInfo[];
   open?: boolean;
   defaultCurrent?: number;

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -103,7 +103,7 @@ exports[`Tour animated placeholder true 1`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -137,7 +137,7 @@ exports[`Tour animated placeholder true 1`] = `
               class="rc-tour-sliders"
             />
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-finish-btn"
@@ -256,7 +256,7 @@ exports[`Tour animated true 1`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -290,7 +290,7 @@ exports[`Tour animated true 1`] = `
               class="rc-tour-sliders"
             />
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-finish-btn"
@@ -548,7 +548,7 @@ exports[`Tour rootClassName 1`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -582,7 +582,7 @@ exports[`Tour rootClassName 1`] = `
               class="rc-tour-sliders"
             />
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-finish-btn"
@@ -664,7 +664,7 @@ exports[`Tour run in strict mode 1`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -705,7 +705,7 @@ exports[`Tour run in strict mode 1`] = `
               />
             </div>
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-next-btn"
@@ -832,7 +832,7 @@ exports[`Tour run in strict mode 2`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -873,7 +873,7 @@ exports[`Tour run in strict mode 2`] = `
               />
             </div>
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-prev-btn"
@@ -950,7 +950,7 @@ exports[`Tour should keep current when controlled 1`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -991,7 +991,7 @@ exports[`Tour should keep current when controlled 1`] = `
               />
             </div>
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-prev-btn"
@@ -1068,7 +1068,7 @@ exports[`Tour should return step 1 when reopen 1`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -1109,7 +1109,7 @@ exports[`Tour should return step 1 when reopen 1`] = `
               />
             </div>
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-next-btn"
@@ -1230,7 +1230,7 @@ exports[`Tour should update position when window resize 1`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -1264,7 +1264,7 @@ exports[`Tour should update position when window resize 1`] = `
               class="rc-tour-sliders"
             />
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-finish-btn"
@@ -1379,7 +1379,7 @@ exports[`Tour showArrow should show tooltip arrow default 1`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -1413,7 +1413,7 @@ exports[`Tour showArrow should show tooltip arrow default 1`] = `
               class="rc-tour-sliders"
             />
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-finish-btn"
@@ -1532,7 +1532,7 @@ exports[`Tour single 1`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -1566,7 +1566,7 @@ exports[`Tour single 1`] = `
               class="rc-tour-sliders"
             />
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-finish-btn"
@@ -1687,7 +1687,7 @@ exports[`Tour use custom builtinPlacements 1`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -1721,7 +1721,7 @@ exports[`Tour use custom builtinPlacements 1`] = `
               class="rc-tour-sliders"
             />
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-finish-btn"
@@ -1842,7 +1842,7 @@ exports[`Tour use custom builtinPlacements 2`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -1876,7 +1876,7 @@ exports[`Tour use custom builtinPlacements 2`] = `
               class="rc-tour-sliders"
             />
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-finish-btn"
@@ -2008,7 +2008,7 @@ exports[`Tour use custom builtinPlacements 3`] = `
         class="rc-tour-content"
       >
         <div
-          class="rc-tour-inner"
+          class="rc-tour-body"
         >
           <button
             aria-label="Close"
@@ -2042,7 +2042,7 @@ exports[`Tour use custom builtinPlacements 3`] = `
               class="rc-tour-sliders"
             />
             <div
-              class="rc-tour-buttons"
+              class="rc-tour-actions"
             >
               <button
                 class="rc-tour-finish-btn"

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`Tour animated placeholder true 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -253,7 +253,7 @@ exports[`Tour animated true 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -545,7 +545,7 @@ exports[`Tour rootClassName 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -661,7 +661,7 @@ exports[`Tour run in strict mode 1`] = `
       style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1001;"
     >
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -829,7 +829,7 @@ exports[`Tour run in strict mode 2`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -947,7 +947,7 @@ exports[`Tour should keep current when controlled 1`] = `
       style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1001;"
     >
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -1065,7 +1065,7 @@ exports[`Tour should return step 1 when reopen 1`] = `
       style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1001;"
     >
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -1227,7 +1227,7 @@ exports[`Tour should update position when window resize 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -1376,7 +1376,7 @@ exports[`Tour showArrow should show tooltip arrow default 1`] = `
       style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1001;"
     >
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -1529,7 +1529,7 @@ exports[`Tour single 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -1684,7 +1684,7 @@ exports[`Tour use custom builtinPlacements 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -1839,7 +1839,7 @@ exports[`Tour use custom builtinPlacements 2`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"
@@ -2005,7 +2005,7 @@ exports[`Tour use custom builtinPlacements 3`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-content"
+        class="rc-tour-section"
       >
         <div
           class="rc-tour-body"

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -100,10 +100,10 @@ exports[`Tour animated placeholder true 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -253,10 +253,10 @@ exports[`Tour animated true 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -545,10 +545,10 @@ exports[`Tour rootClassName 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -661,10 +661,10 @@ exports[`Tour run in strict mode 1`] = `
       style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1001;"
     >
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -829,10 +829,10 @@ exports[`Tour run in strict mode 2`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -947,10 +947,10 @@ exports[`Tour should keep current when controlled 1`] = `
       style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1001;"
     >
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -1065,10 +1065,10 @@ exports[`Tour should return step 1 when reopen 1`] = `
       style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1001;"
     >
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -1227,10 +1227,10 @@ exports[`Tour should update position when window resize 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -1376,10 +1376,10 @@ exports[`Tour showArrow should show tooltip arrow default 1`] = `
       style="left: -1000vw; top: -1000vh; box-sizing: border-box; z-index: 1001;"
     >
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -1529,10 +1529,10 @@ exports[`Tour single 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -1684,10 +1684,10 @@ exports[`Tour use custom builtinPlacements 1`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -1839,10 +1839,10 @@ exports[`Tour use custom builtinPlacements 2`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"
@@ -2005,10 +2005,10 @@ exports[`Tour use custom builtinPlacements 3`] = `
         style="position: absolute;"
       />
       <div
-        class="rc-tour-section"
+        class="rc-tour-pannel"
       >
         <div
-          class="rc-tour-body"
+          class="rc-tour-section"
         >
           <button
             aria-label="Close"

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1088,7 +1088,7 @@ describe('Tour', () => {
   });
 
   it('render rx with 0 instead of 2 when gap.radius is 0', () => {
-    const Demo = ({radius}) => {
+    const Demo = ({ radius }) => {
       const btnRef = useRef<HTMLButtonElement>(null);
       return (
         <div style={{ margin: 20 }}>
@@ -1118,19 +1118,36 @@ describe('Tour', () => {
     expect(targetRect).toHaveAttribute('rx', '0');
   });
 
-  it('disabledInteraction should work', () => {
+  it('support custom styles', () => {
+    const customClassnames = {
+      mask: 'custom-mask',
+      actions: 'custom-actions',
+      title: 'custom-title',
+      header: 'custom-header',
+      content: 'custom-content',
+      body: 'custom-body',
+      footer: 'custom-footer',
+      description: 'custom-description',
+    };
+    const customStyles = {
+      mask: { color: 'white' },
+      actions: { color: 'blue' },
+      title: { fontSize: '20px' },
+      header: { backgroundColor: 'gray' },
+      content: { padding: '10px' },
+      body: { margin: '5px' },
+      footer: { borderTop: '1px solid black' },
+      description: { fontStyle: 'italic' },
+    };
     const Demo = () => {
       const btnRef = useRef<HTMLButtonElement>(null);
       return (
         <div style={{ margin: 20 }}>
           <button ref={btnRef}>按钮</button>
           <Tour
-            placement={'bottom'}
-            gap={{
-              offset: [20, 80],
-            }}
+            classNames={customClassnames}
+            styles={customStyles}
             open
-            disabledInteraction
             steps={[
               {
                 title: '创建',
@@ -1142,11 +1159,47 @@ describe('Tour', () => {
         </div>
       );
     };
-
     render(<Demo />);
 
-    expect(document.querySelector('.rc-tour-mask')).toHaveStyle(
-      'pointer-events: auto',
-    );
+    const maskElement = document.querySelector('.rc-tour-mask') as HTMLElement;
+    const actionsElement = document.querySelector(
+      '.rc-tour-actions',
+    ) as HTMLElement;
+    const titleElement = document.querySelector(
+      '.rc-tour-title',
+    ) as HTMLElement;
+    const headerElement = document.querySelector(
+      '.rc-tour-header',
+    ) as HTMLElement;
+    const contentElement = document.querySelector(
+      '.rc-tour-content',
+    ) as HTMLElement;
+    const bodyElement = document.querySelector('.rc-tour-body') as HTMLElement;
+    const footerElement = document.querySelector(
+      '.rc-tour-footer',
+    ) as HTMLElement;
+    const descriptionElement = document.querySelector(
+      '.rc-tour-description',
+    ) as HTMLElement;
+
+    // check classNames
+    expect(maskElement.classList).toContain('custom-mask');
+    expect(actionsElement.classList).toContain('custom-actions');
+    expect(titleElement.classList).toContain('custom-title');
+    expect(headerElement.classList).toContain('custom-header');
+    expect(contentElement.classList).toContain('custom-content');
+    expect(bodyElement.classList).toContain('custom-body');
+    expect(footerElement.classList).toContain('custom-footer');
+    expect(descriptionElement.classList).toContain('custom-description');
+
+    // check styles
+    expect(maskElement.style.color).toBe('white');
+    expect(actionsElement.style.color).toBe('blue');
+    expect(titleElement.style.fontSize).toBe('20px');
+    expect(headerElement.style.backgroundColor).toBe('gray');
+    expect(contentElement.style.padding).toBe('10px');
+    expect(bodyElement.style.margin).toBe('5px');
+    expect(footerElement.style.borderTop).toBe('1px solid black');
+    expect(descriptionElement.style.fontStyle).toBe('italic');
   });
 });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1125,7 +1125,6 @@ describe('Tour', () => {
       title: 'custom-title',
       header: 'custom-header',
       section: 'custom-section',
-      body: 'custom-body',
       footer: 'custom-footer',
       description: 'custom-description',
     };
@@ -1135,7 +1134,6 @@ describe('Tour', () => {
       title: { fontSize: '20px' },
       header: { backgroundColor: 'gray' },
       section: { padding: '10px' },
-      body: { margin: '5px' },
       footer: { borderTop: '1px solid black' },
       description: { fontStyle: 'italic' },
     };
@@ -1174,7 +1172,6 @@ describe('Tour', () => {
     const sectionElement = document.querySelector(
       '.rc-tour-section',
     ) as HTMLElement;
-    const bodyElement = document.querySelector('.rc-tour-body') as HTMLElement;
     const footerElement = document.querySelector(
       '.rc-tour-footer',
     ) as HTMLElement;
@@ -1188,7 +1185,6 @@ describe('Tour', () => {
     expect(titleElement.classList).toContain('custom-title');
     expect(headerElement.classList).toContain('custom-header');
     expect(sectionElement.classList).toContain('custom-section');
-    expect(bodyElement.classList).toContain('custom-body');
     expect(footerElement.classList).toContain('custom-footer');
     expect(descriptionElement.classList).toContain('custom-description');
 
@@ -1198,7 +1194,6 @@ describe('Tour', () => {
     expect(titleElement.style.fontSize).toBe('20px');
     expect(headerElement.style.backgroundColor).toBe('gray');
     expect(sectionElement.style.padding).toBe('10px');
-    expect(bodyElement.style.margin).toBe('5px');
     expect(footerElement.style.borderTop).toBe('1px solid black');
     expect(descriptionElement.style.fontStyle).toBe('italic');
   });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1124,7 +1124,7 @@ describe('Tour', () => {
       actions: 'custom-actions',
       title: 'custom-title',
       header: 'custom-header',
-      content: 'custom-content',
+      section: 'custom-section',
       body: 'custom-body',
       footer: 'custom-footer',
       description: 'custom-description',
@@ -1134,7 +1134,7 @@ describe('Tour', () => {
       actions: { color: 'blue' },
       title: { fontSize: '20px' },
       header: { backgroundColor: 'gray' },
-      content: { padding: '10px' },
+      section: { padding: '10px' },
       body: { margin: '5px' },
       footer: { borderTop: '1px solid black' },
       description: { fontStyle: 'italic' },
@@ -1171,8 +1171,8 @@ describe('Tour', () => {
     const headerElement = document.querySelector(
       '.rc-tour-header',
     ) as HTMLElement;
-    const contentElement = document.querySelector(
-      '.rc-tour-content',
+    const sectionElement = document.querySelector(
+      '.rc-tour-section',
     ) as HTMLElement;
     const bodyElement = document.querySelector('.rc-tour-body') as HTMLElement;
     const footerElement = document.querySelector(
@@ -1187,7 +1187,7 @@ describe('Tour', () => {
     expect(actionsElement.classList).toContain('custom-actions');
     expect(titleElement.classList).toContain('custom-title');
     expect(headerElement.classList).toContain('custom-header');
-    expect(contentElement.classList).toContain('custom-content');
+    expect(sectionElement.classList).toContain('custom-section');
     expect(bodyElement.classList).toContain('custom-body');
     expect(footerElement.classList).toContain('custom-footer');
     expect(descriptionElement.classList).toContain('custom-description');
@@ -1197,7 +1197,7 @@ describe('Tour', () => {
     expect(actionsElement.style.color).toBe('blue');
     expect(titleElement.style.fontSize).toBe('20px');
     expect(headerElement.style.backgroundColor).toBe('gray');
-    expect(contentElement.style.padding).toBe('10px');
+    expect(sectionElement.style.padding).toBe('10px');
     expect(bodyElement.style.margin).toBe('5px');
     expect(footerElement.style.borderTop).toBe('1px solid black');
     expect(descriptionElement.style.fontStyle).toBe('italic');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 为导览组件（Tour）添加了自定义样式和类名的能力
	- 支持对导览组件的不同语义元素（如遮罩、标题、内容、页脚等）进行精细化样式定制

- **样式调整**
	- 重命名了导览组件内部样式类名
	- 优化了组件的样式灵活性

- **测试更新**
	- 扩展了测试用例，验证自定义样式和类名功能
	- 增加了对组件样式和行为的全面测试覆盖
<!-- end of auto-generated comment: release notes by coderabbit.ai -->