### PR TITLE
chore: bump father plugin

### DIFF
--- a/.fatherrc.js
+++ b/.fatherrc.js
@@ -1,10 +1,5 @@
 import { defineConfig } from 'father';
 
 export default defineConfig({
-  platform: 'browser',
-  cjs: { output: 'lib' },
-  esm: {
-    output: 'es',
-    alias: { 'rc-util/lib': 'rc-util/es' },
-  },
+  plugins: ['@rc-component/father-plugin'],
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rc-component/tour",
-  "version": "1.15.1",
+  "version": "2.0.0-0",
   "description": "React tour Component",
   "keywords": [
     "react",
@@ -33,7 +33,7 @@
     "lint:tsc": "tsc -p tsconfig.json --noEmit",
     "now-build": "npm run docs:build",
     "prepare": "dumi setup",
-    "prepublishOnly": "npm run compile && np --no-cleanup --yolo --no-publish",
+    "prepublishOnly": "npm run compile && rc-np",
     "prettier": "prettier --write \"**/*.{js,jsx,tsx,ts,less,md,json}\"",
     "start": "dumi dev",
     "test": "umi-test",
@@ -47,22 +47,23 @@
     "rc-util": "^5.24.4"
   },
   "devDependencies": {
+    "@rc-component/father-plugin": "^2.0.3",
+    "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^15.0.0",
     "@types/jest": "^29.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@umijs/fabric": "^2.5.2",
+    "cheerio": "1.0.0-rc.12",
     "dumi": "^2.1.2",
     "eslint": "^7.18.0",
-    "father": "^4.0.0-rc.8",
+    "father": "^4.0.0",
     "gh-pages": "^3.1.0",
-    "np": "^5.0.3",
     "prettier": "^3.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "typescript": "^5.0.0",
-    "cheerio": "1.0.0-rc.12",
     "umi-test": "^1.9.7"
   },
   "peerDependencies": {


### PR DESCRIPTION
follow up https://github.com/react-component/tour/pull/70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **版本更新**
	- 包版本从 1.15.1 升级到 2.0.0-0

- **依赖变更**
	- 添加 @rc-component/father-plugin 和 @rc-component/np 依赖
	- 更新 father 依赖到最新版本
	- 移除 np 依赖

- **构建配置**
	- 更新 .fatherrc.js 配置，引入新的构建插件

- **发布脚本**
	- 修改 prepublishOnly 脚本，使用新的发布命令 rc-np

<!-- end of auto-generated comment: release notes by coderabbit.ai -->