### PR TITLE
refactor: remove getTriggerDOMNode usage

### DIFF
--- a/src/Placeholder.tsx
+++ b/src/Placeholder.tsx
@@ -1,0 +1,31 @@
+import Portal, { type PortalProps } from '@rc-component/portal';
+import * as React from 'react';
+
+export interface PlaceholderProps
+  extends Pick<PortalProps, 'open' | 'autoLock' | 'getContainer'> {
+  domRef: React.RefObject<HTMLDivElement>;
+  className: string;
+  style: React.CSSProperties;
+  proxyDom: () => HTMLElement | null;
+}
+
+const Placeholder = React.forwardRef<HTMLElement, PlaceholderProps>(
+  (props, ref) => {
+    const { open, autoLock, getContainer, domRef, className, style, proxyDom } =
+      props;
+
+    React.useImperativeHandle(ref, () => domRef.current || proxyDom());
+
+    return (
+      <Portal open={open} autoLock={autoLock} getContainer={getContainer}>
+        <div ref={domRef} className={className} style={style} />
+      </Portal>
+    );
+  },
+);
+
+if (process.env.NODE_ENV !== 'production') {
+  Placeholder.displayName = 'Placeholder';
+}
+
+export default Placeholder;

--- a/src/Placeholder.tsx
+++ b/src/Placeholder.tsx
@@ -6,15 +6,22 @@ export interface PlaceholderProps
   domRef: React.RefObject<HTMLDivElement>;
   className: string;
   style: React.CSSProperties;
-  proxyDom: () => HTMLElement | null;
+  fallbackDOM: () => HTMLElement | null;
 }
 
 const Placeholder = React.forwardRef<HTMLElement, PlaceholderProps>(
   (props, ref) => {
-    const { open, autoLock, getContainer, domRef, className, style, proxyDom } =
-      props;
+    const {
+      open,
+      autoLock,
+      getContainer,
+      domRef,
+      className,
+      style,
+      fallbackDOM,
+    } = props;
 
-    React.useImperativeHandle(ref, () => domRef.current || proxyDom());
+    React.useImperativeHandle(ref, () => domRef.current || fallbackDOM());
 
     return (
       <Portal open={open} autoLock={autoLock} getContainer={getContainer}>

--- a/src/Tour.tsx
+++ b/src/Tour.tsx
@@ -202,7 +202,7 @@ const Tour: React.FC<TourProps> = props => {
     typeof mergedMask === 'boolean' ? undefined : mergedMask;
 
   // when targetElement is not exist, use body as triggerDOMNode
-  const proxyDom = () => {
+  const fallbackDOM = () => {
     return targetElement || document.body;
   };
 
@@ -245,7 +245,7 @@ const Tour: React.FC<TourProps> = props => {
           autoLock={!inlineMode}
           getContainer={getPopupContainer as any}
           domRef={placeholderRef}
-          proxyDom={proxyDom}
+          fallbackDOM={fallbackDOM}
           className={classNames(
             className,
             rootClassName,

--- a/src/Tour.tsx
+++ b/src/Tour.tsx
@@ -14,6 +14,7 @@ import Mask from './Mask';
 import { getPlacements } from './placements';
 import TourStep from './TourStep';
 import { getPlacement } from './util';
+import Placeholder from './Placeholder';
 
 const CENTER_PLACEHOLDER: React.CSSProperties = {
   left: '50%',
@@ -201,8 +202,8 @@ const Tour: React.FC<TourProps> = props => {
     typeof mergedMask === 'boolean' ? undefined : mergedMask;
 
   // when targetElement is not exist, use body as triggerDOMNode
-  const getTriggerDOMNode = node => {
-    return node || targetElement || document.body;
+  const proxyDom = () => {
+    return targetElement || document.body;
   };
 
   return (
@@ -237,29 +238,26 @@ const Tour: React.FC<TourProps> = props => {
         forceRender={false}
         autoDestroy
         zIndex={zIndex}
-        getTriggerDOMNode={getTriggerDOMNode}
         arrow={!!mergedArrow}
       >
-        <Portal
+        <Placeholder
           open={mergedOpen}
           autoLock={!inlineMode}
           getContainer={getPopupContainer as any}
-        >
-          <div
-            ref={placeholderRef}
-            className={classNames(
-              className,
-              rootClassName,
-              `${prefixCls}-target-placeholder`,
-            )}
-            style={{
-              ...(posInfo || CENTER_PLACEHOLDER),
-              position: inlineMode ? 'absolute' : 'fixed',
-              pointerEvents: 'none',
-              ...style,
-            }}
-          />
-        </Portal>
+          domRef={placeholderRef}
+          proxyDom={proxyDom}
+          className={classNames(
+            className,
+            rootClassName,
+            `${prefixCls}-target-placeholder`,
+          )}
+          style={{
+            ...(posInfo || CENTER_PLACEHOLDER),
+            position: inlineMode ? 'absolute' : 'fixed',
+            pointerEvents: 'none',
+            ...style,
+          }}
+        />
       </Trigger>
     </>
   );


### PR DESCRIPTION
follow up https://github.com/react-component/select/pull/1149

移除 `getTriggerDOMNode` 后，`rc-trigger` 中也将移除该方法支持。