### PR TITLE
feat: feat: support array of gap offsets for Tour steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ We use typescript to create the Type definition. You can view directly in IDE. B
 | style | `React.CSSProperties` | - | - |
 | scrollIntoViewOptions | `boolean \| ScrollIntoViewOptions` | `true` | 是否支持当前元素滚动到视窗内，也可传入配置指定滚动视窗的相关参数，默认跟随 Tour 的 `scrollIntoViewOptions` 属性 |
 
+### TourInstance
+<!-- prettier-ignore -->
+| 属性 | 类型 | 说明 | 版本 |
+| --- | --- | --- | --- |
+| next |  `() => void` | 跳转到下一步 | 2.2.0 |
+| prev |  `() => void` | 跳转到上一步 | 2.2.0 |
+| close |  `() => void` | 关闭步骤 | 2.2.0 |
+| finish |  `() => void` | 结束步骤 | 2.2.0 |
+
+
 ## 🤝 Contributing 
 
 <a href="https://openomy.app/github/react-component/tour" target="_blank" style="display: block; width: 100%;" align="center">

--- a/docs/demo/gap.md
+++ b/docs/demo/gap.md
@@ -16,3 +16,7 @@ nav:
 ## Radius
 
 <code src="../examples/gap-radius.tsx"></code>
+
+## Offset
+
+<code src="../examples/gap-offset-array.tsx"></code>

--- a/docs/examples/gap-offset-array.tsx
+++ b/docs/examples/gap-offset-array.tsx
@@ -1,0 +1,59 @@
+import { useRef, useState } from 'react';
+import Tour from '../../src/index';
+import './basic.less';
+
+const App = () => {
+  const button1Ref = useRef<HTMLButtonElement>(null);
+  const button2Ref = useRef<HTMLButtonElement>(null);
+  const button3Ref = useRef<HTMLButtonElement>(null);
+  
+  const [open, setOpen] = useState(false);
+  const offset: [number, number][] = [
+    [10, 10],
+    [20, 20],
+  ]
+  return (
+    <div style={{ margin: 20 }}>
+      <div style={{ display: 'flex', gap: 10 }}>
+        <button onClick={() => setOpen(true)}>Open</button>
+        <button ref={button1Ref}>button 1</button>
+        <button ref={button2Ref}>button 2</button>
+        <button ref={button3Ref}>button 3</button>
+      </div>
+
+
+      <div style={{ height: 200 }} />
+      <Tour
+        open={open}
+        gap={{
+          offset
+        }}
+        steps={[
+          {
+            title: '创建1',
+            description: '创建一条数据1',
+            target: () => button1Ref.current,
+            mask: true,
+          },
+          {
+            title: '创建2',
+            description: '创建一条数据2',
+            target: () => button2Ref.current,
+            mask: true,
+          },
+          {
+            title: '创建3',
+            description: '创建一条数据3',
+            target: () => button3Ref.current,
+            mask: true,
+          },
+        ]}
+        onClose={() => {
+          setOpen(false);
+        }}
+      />
+    </div>
+  );
+};
+
+export default App;

--- a/src/Tour.tsx
+++ b/src/Tour.tsx
@@ -158,6 +158,7 @@ const Tour = React.forwardRef<TourRef, TourProps>((props: TourProps, ref) => {
     mergedScrollIntoViewOptions,
     inlineMode,
     placeholderRef,
+    mergedCurrent,
   );
   const mergedPlacement = getPlacement(targetElement, placement, stepPlacement);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
 import Tour from './Tour';
-export type { TourProps, TourStepInfo, TourStepProps } from './interface';
+export type { TourProps, TourStepInfo, TourStepProps, TourRef } from './interface';
 
 export default Tour;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -14,14 +14,19 @@ export type SemanticName =
   | 'mask';
 
 
-export type HTMLAriaDataAttributes = React.AriaAttributes & {
-  [key: `data-${string}`]: unknown;
-} & Pick<React.HTMLAttributes<HTMLDivElement>, 'role'>;
+export type HTMLAriaDataAttributes = React.AriaAttributes & Record<`data-${string}`, unknown> & Pick<React.HTMLAttributes<HTMLDivElement>, 'role'>;
+
+export interface TourRef {
+  next: () => void;
+  prev: () => void;
+  close: () => void;
+  finish: () => void;
+}
 
 export interface TourStepInfo {
   arrow?: boolean | { pointAtCenter: boolean };
   target?: HTMLElement | (() => HTMLElement) | null | (() => null);
-  title: ReactNode;
+  title?: ReactNode;
   description?: ReactNode;
   placement?: PlacementType;
   mask?:
@@ -36,6 +41,7 @@ export interface TourStepInfo {
   scrollIntoViewOptions?: boolean | ScrollIntoViewOptions;
   closeIcon?: ReactNode;
   closable?: boolean | ({ closeIcon?: ReactNode } & HTMLAriaDataAttributes);
+  contentRender?: (next: () => void, prev: () => void, close: () => void, finish: () => void) => ReactNode;
 }
 
 export interface TourStepProps extends TourStepInfo {
@@ -49,6 +55,7 @@ export interface TourStepProps extends TourStepInfo {
   onNext?: () => void;
   classNames?: Partial<Record<SemanticName, string>>;
   styles?: Partial<Record<SemanticName, React.CSSProperties>>;
+  contentRender?: (next: () => void, prev: () => void, close: () => void, finish: () => void) => ReactNode;
 }
 
 export interface TourProps extends Pick<TriggerProps, 'onPopupAlign'> {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1375,4 +1375,86 @@ describe('Tour', () => {
       expect(document.querySelector('.rc-tour-pannel')).toBeFalsy();
     }
   });
+
+  it('should support gap.offset with array<[number, number]> and change on next step', async () => {
+    mockBtnRect({
+      x: 100,
+      y: 100,
+      width: 230,
+      height: 180,
+    });
+    
+    const Demo = () => {
+      const button1Ref = useRef<HTMLButtonElement>(null);
+      const button2Ref = useRef<HTMLButtonElement>(null);
+      const button3Ref = useRef<HTMLButtonElement>(null);
+      
+      return (
+        <div style={{ margin: 20 }}>
+          <button ref={button1Ref}>button 1</button>
+          <button ref={button2Ref}>button 2</button>
+          <button ref={button3Ref}>button 3</button>
+          <Tour
+            open
+            gap={{
+              offset: [[10, 15], [20, 25], [30, 35]] as [number, number][],
+            }}
+            steps={[
+              {
+                title: 'step 1',
+                description: 'description 1',
+                target: () => button1Ref.current,
+              },
+              {
+                title: 'step 2', 
+                description: 'description 2',
+                target: () => button2Ref.current,
+              },
+              {
+                title: 'step 3',
+                description: 'description 3', 
+                target: () => button3Ref.current,
+              },
+            ]}
+          />
+        </div>
+      );
+    };
+    
+    render(<Demo />);
+    await act(() => {
+      jest.runAllTimers();
+    });
+    
+    // gap [10, 15] -> width: 230 + 20 = 250, height: 180 + 30 = 210
+    let targetRect = document
+      .getElementById('rc-tour-mask-test-id')
+      .querySelectorAll('rect')[1];
+    expect(targetRect).toHaveAttribute('width', '250');
+    expect(targetRect).toHaveAttribute('height', '210');
+    
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await act(() => {
+      jest.runAllTimers();
+    });
+    
+    // gap [20, 25] -> width: 230 + 40 = 270, height: 180 + 50 = 230
+    targetRect = document
+      .getElementById('rc-tour-mask-test-id')
+      .querySelectorAll('rect')[1];
+    expect(targetRect).toHaveAttribute('width', '270');
+    expect(targetRect).toHaveAttribute('height', '230');
+    
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    await act(() => {
+      jest.runAllTimers();
+    });
+    
+    // gap [30, 35] -> width: 230 + 60 = 290, height: 180 + 70 = 250
+    targetRect = document
+      .getElementById('rc-tour-mask-test-id')
+      .querySelectorAll('rect')[1];
+    expect(targetRect).toHaveAttribute('width', '290');
+    expect(targetRect).toHaveAttribute('height', '250');
+  });
 });


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature

### 🔗 Related Issues
[https://github.com/ant-design/ant-design/issues/54204](https://github.com/ant-design/ant-design/issues/54204)

### 💡 Background and Solution
tour would like to support configuring offset separately 
Add the [number, number][] type to the offset in the useTarget hook

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | gap.offset Added the type [number, number][] |
| 🇨🇳 Chinese | gap.offset 新增 [number, number][] 类型 |
