### PR TITLE
feat: adapt semantic close

### DIFF
--- a/src/TourStep/DefaultPanel.tsx
+++ b/src/TourStep/DefaultPanel.tsx
@@ -40,7 +40,7 @@ export default function DefaultPanel(props: DefaultPanelProps) {
             onClick={onClose}
             aria-label="Close"
             {...ariaProps}
-            className={classNames(`${prefixCls}-close`, tourClassNames?.close)}
+            className={clsx(`${prefixCls}-close`, tourClassNames?.close)}
             style={styles?.close}
           >
             {closeIcon}

--- a/src/TourStep/DefaultPanel.tsx
+++ b/src/TourStep/DefaultPanel.tsx
@@ -41,7 +41,8 @@ export default function DefaultPanel(props: DefaultPanelProps) {
             onClick={onClose}
             aria-label="Close"
             {...ariaProps}
-            className={`${prefixCls}-close`}
+            className={classNames(`${prefixCls}-close`, tourClassNames?.close)}
+            style={styles?.close}
           >
             {closeIcon}
           </button>

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -11,7 +11,8 @@ export type SemanticName =
   | 'header'
   | 'title'
   | 'description'
-  | 'mask';
+  | 'mask'
+  | 'close';
 
 
 export type HTMLAriaDataAttributes = React.AriaAttributes & {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1127,6 +1127,7 @@ describe('Tour', () => {
       section: 'custom-section',
       footer: 'custom-footer',
       description: 'custom-description',
+      close: 'custom-close',
     };
     const customStyles = {
       mask: { color: 'white' },
@@ -1136,6 +1137,7 @@ describe('Tour', () => {
       section: { padding: '10px' },
       footer: { borderTop: '1px solid black' },
       description: { fontStyle: 'italic' },
+      close: { color: 'red' },
     };
     const Demo = () => {
       const btnRef = useRef<HTMLButtonElement>(null);
@@ -1178,6 +1180,9 @@ describe('Tour', () => {
     const descriptionElement = document.querySelector(
       '.rc-tour-description',
     ) as HTMLElement;
+    const closeElement = document.querySelector(
+      '.rc-tour-close',
+    ) as HTMLElement;
 
     // check classNames
     expect(maskElement.classList).toContain('custom-mask');
@@ -1187,6 +1192,7 @@ describe('Tour', () => {
     expect(sectionElement.classList).toContain('custom-section');
     expect(footerElement.classList).toContain('custom-footer');
     expect(descriptionElement.classList).toContain('custom-description');
+    expect(closeElement.classList).toContain('custom-close');
 
     // check styles
     expect(maskElement.style.color).toBe('white');
@@ -1196,6 +1202,7 @@ describe('Tour', () => {
     expect(sectionElement.style.padding).toBe('10px');
     expect(footerElement.style.borderTop).toBe('1px solid black');
     expect(descriptionElement.style.fontStyle).toBe('italic');
+    expect(closeElement.style.color).toBe('red');
   });
 
   it('inline', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 引导浮层的关闭按钮现支持自定义类名与内联样式，便于品牌化与主题定制，兼容现有前缀类。
  - 扩展可用样式语义名，新增 “close”（保留 “mask”），可精细化定制关闭元素外观，向后兼容运行逻辑。

- 测试
  - 增加关闭按钮相关测试，验证类名、样式、可见性与无障碍属性在多步场景下的行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->