### PR TITLE
Avoid deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   "dependencies": {
     "@rc-component/portal": "^2.2.0",
     "@rc-component/trigger": "^3.0.0",
-    "@rc-component/util": "^1.7.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.3",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^15.0.0",

--- a/src/Mask.tsx
+++ b/src/Mask.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { clsx } from 'clsx';
 import Portal from '@rc-component/portal';
 import type { PosInfo } from './hooks/useTarget';
-import useId from '@rc-component/util/lib/hooks/useId';
+import { useId } from '@rc-component/util';
 import type { SemanticName, TourProps } from './interface';
 
 const COVER_PROPS: React.SVGAttributes<SVGRectElement> = {

--- a/src/Tour.tsx
+++ b/src/Tour.tsx
@@ -3,10 +3,12 @@ import * as React from 'react';
 import type { TriggerRef } from '@rc-component/trigger';
 import Trigger from '@rc-component/trigger';
 import { clsx } from 'clsx';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
+import {
+  KeyCode,
+  useControlledState,
+  useEvent,
+  useLayoutEffect,
+} from '@rc-component/util';
 import { useMemo } from 'react';
 import { useClosable } from './hooks/useClosable';
 import useTarget from './hooks/useTarget';

--- a/src/TourStep/DefaultPanel.tsx
+++ b/src/TourStep/DefaultPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { TourStepProps } from '../interface';
 import { clsx } from 'clsx';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { pickAttrs } from '@rc-component/util';
 
 export type DefaultPanelProps = Exclude<TourStepProps, 'closable'> & {
   closable: Exclude<TourStepProps['closable'], boolean>;

--- a/src/hooks/useTarget.ts
+++ b/src/hooks/useTarget.ts
@@ -1,5 +1,4 @@
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { useEvent, useLayoutEffect } from '@rc-component/util';
 import { useMemo, useState } from 'react';
 import type { TourStepInfo } from '..';
 import { isInViewPort } from '../util';

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import type { ReactNode } from 'react';
 import React, { StrictMode, useRef, useState } from 'react';
 import { act } from 'react-dom/test-utils';


### PR DESCRIPTION
## 变更内容

- 升级 `@rc-component/util` 到包含根入口导出的版本，并升级 `@rc-component/father-plugin`。
- 将 `@rc-component/util` 的 `lib` 深路径导入调整为包根入口导入。
- 测试中 `spyElementPrototypes` 也改为从 `@rc-component/util` 根入口导入。

## 验证

- `npm run lint` 通过，保留既有 warning。
- `npm test -- --runInBand` 通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新日志

* **Chores（维护）**
  * 更新依赖包版本至最新兼容版本
  * 调整内部代码结构以适配依赖更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/tour/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->