### PR TITLE
ci: deploy documentation with reusable workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,15 @@
+name: Deploy documentation
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    uses: react-component/rc-test/.github/workflows/deploy-pages.yml@main


### PR DESCRIPTION
## Summary

- deploy documentation on published releases and manual dispatches
- reuse the shared react-component Pages workflow

## Verification

- `ut --registry https://registry.npmjs.org/`
- `GH_PAGES=1 ut run build`